### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text storage of sensitive information

### DIFF
--- a/src/google/adk/cli/cli_create.py
+++ b/src/google/adk/cli/cli_create.py
@@ -190,7 +190,10 @@ def _generate_files(
     elif google_cloud_project and google_cloud_region:
       lines.append("GOOGLE_GENAI_USE_VERTEXAI=1")
     if google_api_key:
-      lines.append(f"GOOGLE_API_KEY={google_api_key}")
+      click.secho(
+          "NOTE: For security, the GOOGLE_API_KEY was NOT written to `.env`. Please set it as an environment variable manually and do not check secrets into source control.",
+          fg="yellow",
+      )
     if google_cloud_project:
       lines.append(f"GOOGLE_CLOUD_PROJECT={google_cloud_project}")
     if google_cloud_region:


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/adk-python/security/code-scanning/2](https://github.com/venkateshpabbati/adk-python/security/code-scanning/2)

**General approach:**  
To address the risk of clear-text storage of sensitive information, the code should never write a sensitive credential such as a Google API key directly to disk in plaintext. The best fix is to avoid writing the API key to the `.env` file at all. Instead, the code should either:  
- Require the user (or their environment) to set the `GOOGLE_API_KEY` environment variable themselves,  
- Or, if writing the API key is absolutely necessary, encrypt/obfuscate it before storing, and add secure instructions for decryption (which is complex and uncommon in CLI tools).

**Specific best fix:**  
Remove the line writing the `GOOGLE_API_KEY` value to the `.env` file in `_generate_files()`. Instead, inform the user that they need to set the `GOOGLE_API_KEY` environment variable manually, and add a clear message reminding them not to check secrets into version control. This ensures no sensitive data is inadvertently written to disk.

**File/region to change:**  
- In `src/google/adk/cli/cli_create.py`, lines 193–194, do not append the `GOOGLE_API_KEY` line to the `lines` list.
- Optionally, display a `click.secho` info message to the user indicating that they need to set `GOOGLE_API_KEY` themselves.
- No need for additional imports or dependencies.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
