### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text storage of sensitive information

### DIFF
--- a/src/google/adk/cli/cli_create.py
+++ b/src/google/adk/cli/cli_create.py
@@ -192,7 +192,8 @@ def _generate_files(
     elif google_cloud_project and google_cloud_region:
       lines.append("GOOGLE_GENAI_USE_VERTEXAI=1")
     if google_api_key:
-      lines.append(f"GOOGLE_API_KEY={google_api_key}")
+      # Do not store the Google API key in clear text; instruct the user instead.
+      lines.append("# Set GOOGLE_API_KEY in your environment before running.")
     if google_cloud_project:
       lines.append(f"GOOGLE_CLOUD_PROJECT={google_cloud_project}")
     if google_cloud_region:


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/adk-python/security/code-scanning/1](https://github.com/venkateshpabbati/adk-python/security/code-scanning/1)

In general, the safest fix is to avoid storing secrets (API keys, passwords) in clear text on disk. Instead, store a non-sensitive reference (like the name of an environment variable or a configuration hint) and require the user to set the secret in their own environment or secret manager. If storing something is unavoidable, it should be encrypted with a key not checked into source, but for a simple CLI scaffolding tool, the better design is to omit the secret entirely.

For this code, the minimal, non–behavior-breaking approach is:

- Stop writing the actual value of `google_api_key` into the `.env` file.
- Instead, if a Google API key is needed, write a commented placeholder line guiding the user to set `GOOGLE_API_KEY` themselves, or write nothing at all for the key.
- Keep writing the non-sensitive configuration values (`GOOGLE_GENAI_USE_VERTEXAI`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`) as before.

Concretely, in `_generate_files` in `src/google/adk/cli/cli_create.py`:

- Replace the line `lines.append(f"GOOGLE_API_KEY={google_api_key}")` with a safe alternative such as a comment placeholder (e.g., `# Set GOOGLE_API_KEY in your environment`) and do not persist the actual key value.
- Ensure the rest of the logic is unchanged so that all existing flows that depend on the `.env` file structure continue to work, but without clear-text storage of the secret.

No new methods or complex logic are required; only the block where `lines` is populated needs to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
