### PR TITLE
Potential fix for code scanning alert no. 25: Clear text transmission of sensitive cookie

### DIFF
--- a/contributing/samples/integrations/gcp_auth/client/static/script.js
+++ b/contributing/samples/integrations/gcp_auth/client/static/script.js
@@ -213,7 +213,7 @@ $(function() {
 
     currentSessionId = null;
     document.cookie =
-        'session_id=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; samesite=lax';
+        'session_id=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; samesite=lax; secure';
 
     resetChatFeed();
     updateAgentInfoPane();


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/adk-python/security/code-scanning/25](https://github.com/venkateshpabbati/adk-python/security/code-scanning/25)

To fix this class of issue, ensure cookies related to session/authentication are always set with `Secure` so they are only transmitted over HTTPS. In client-side JavaScript, this means appending `; secure` to the `document.cookie` string whenever such cookies are written (including when clearing them). Keep existing behavior (same name, expiration, path, SameSite) unchanged.

In `contributing/samples/integrations/gcp_auth/client/static/script.js`, update the cookie-clear line in the `#save-settings` click handler (around lines 215–216) to include `secure`. No new imports, helper methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
