### PR TITLE
Potential fix for code scanning alert no. 64: Uncontrolled data used in path expression

### DIFF
--- a/contributing/samples/integrations/gcp_auth/client/main.py
+++ b/contributing/samples/integrations/gcp_auth/client/main.py
@@ -167,7 +167,21 @@ async def chat(request: ChatRequest, response: Response):
       return stream_error("No local agent specified.")
 
     # Validate that the local agent exists in the project directory
-    agent_file = os.path.join(AGENT_PROJECT_DIR, f"{request.local_agent}.py")
+    if (
+        os.path.isabs(request.local_agent)
+        or "/" in request.local_agent
+        or "\\" in request.local_agent
+        or ".." in request.local_agent
+    ):
+      return stream_error("Invalid local agent name.")
+
+    base_dir = os.path.realpath(AGENT_PROJECT_DIR)
+    agent_file = os.path.realpath(
+        os.path.join(base_dir, f"{request.local_agent}.py")
+    )
+    if os.path.commonpath([base_dir, agent_file]) != base_dir:
+      return stream_error("Invalid local agent path.")
+
     if not os.path.exists(agent_file):
       return stream_error(
           f"Local agent module {request.local_agent} not found in"


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/adk-python/security/code-scanning/64](https://github.com/venkateshpabbati/adk-python/security/code-scanning/64)

To fix this safely without changing intended functionality, validate `request.local_agent` before constructing/using `agent_file`:

1. Build the candidate path under `AGENT_PROJECT_DIR`.
2. Normalize both base and candidate with `os.path.realpath`.
3. Enforce containment using `os.path.commonpath([base, candidate]) == base`.
4. Reject suspicious module names (path separators, absolute paths, traversal) before `importlib.import_module`.
5. Keep existing behavior for valid module names and existing files.

In `contributing/samples/integrations/gcp_auth/client/main.py`, update the `/chat` local-agent branch around lines 169–176 to perform canonical path containment checks and return `stream_error` on invalid input. No new dependencies are needed; `os` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
